### PR TITLE
Add version suffix to deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           environment:
             GORELEASER_URL: "https://github.com/goreleaser/goreleaser/releases/download/v0.82.1/goreleaser_Linux_x86_64.tar.gz"
           name: Download goreleaser
-          command: curl -L -s ${GORELEASER_URL} | sudo tar zxvf - -C /usr/local/bin
+          command: curl -L -s ${GORELEASER_URL} | sudo tar zxf - -C /usr/local/bin
       - run:
           name: Release
           command: /usr/local/bin/goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
   - go get -v -t -d
 builds:
 - main: main.go
-  binary: terraform-provider-shell-{{.Version}}
+  binary: terraform-provider-shell-v{{.Version}}
   goos:
     - linux
     - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,4 +8,9 @@ builds:
     - linux
     - windows
   goarch:
-    - amd64
+  - amd64
+s3:
+-
+  bucket: d2l-terraform-registry
+  region: us-east-1
+  folder: "providers/terraform-provider-shell/{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
   - go get -v -t -d
 builds:
 - main: main.go
-  binary: terraform-provider-shell-v{{.Version}}
+  binary: terraform-provider-shell_v{{.Version}}
   goos:
     - linux
     - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,11 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+  - go get -v -t -d
 builds:
-- goos:
-  - linux
-  - windows
+- main: main.go
+  binary: terraform-provider-shell-{{.Version}}
+  goos:
+    - linux
+    - windows
   goarch:
-  - amd64
+    - amd64


### PR DESCRIPTION
Add version suffix to deployments so that actions such as `terraform providers -v` list the version of the provider.