### PR TITLE
Add global variable to provider

### DIFF
--- a/shell/config.go
+++ b/shell/config.go
@@ -2,4 +2,6 @@ package shell
 
 type Config struct {
 	WorkingDirectory string
+	Variables        map[string]interface{}
+	Prune            []string
 }

--- a/shell/provider.go
+++ b/shell/provider.go
@@ -14,6 +14,20 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("PWD", nil),
 				Description: "The working directory where to run.",
 			},
+			"variables": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"prune": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -25,8 +39,16 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	pruneRaw := d.Get("prune").([]interface{})
+	prune := make([]string, len(pruneRaw))
+	for i, vI := range pruneRaw {
+		prune[i] = vI.(string)
+	}
+
 	config := Config{
 		WorkingDirectory: d.Get("working_directory").(string),
+		Variables:        d.Get("variables").(map[string]interface{}),
+		Prune:            prune,
 	}
 
 	return &config, nil


### PR DESCRIPTION
Perform a hack-n-slack approach t

* Add global variables, allowing more sensitive variables to be passed to the shell
* Provide a hacky way of ignoring output text when we are unable to control the output from a script

As an aside, a better way of setting up some of our exec tooling could be done by using two resources instead of one:

* `external_cmd`: Defines the lifecycle commands / properties for a CLI/script
* `external`: Executes the `external_cmd` definition with a specific set of parameters