### PR TITLE
Timeout on commands executed by the provider

### DIFF
--- a/examples/delayed/Command.ps1
+++ b/examples/delayed/Command.ps1
@@ -1,0 +1,8 @@
+param(
+    [String]$Action
+)
+$ProgressPreference='SilentlyContinue'
+$ConfirmPreference ='None'
+
+# Sleep for 2 hours
+Start-Sleep -Seconds (2*3600)

--- a/examples/delayed/README.md
+++ b/examples/delayed/README.md
@@ -1,0 +1,11 @@
+# Script Timeout
+
+This example describes a script that hangs for a long period of time, that will be terminated if it fails to complete within the expected duration.
+
+## How to Run
+
+You will need to have PowerShell configured on your machine to run this example. If you are on Ubuntu, you can use PowerShell Core.
+
+```bash
+terraform apply 
+````

--- a/examples/delayed/main.tf
+++ b/examples/delayed/main.tf
@@ -1,0 +1,17 @@
+provider "shell" {
+  variables = {
+    Message = "Hello, World!"
+  }
+}
+
+resource "shell" "default" {
+  create = ["pwsh", "-File", "${path.module}/Command.ps1", "-Action", "create"]
+  read   = ["pwsh", "-File", "${path.module}/Command.ps1", "-Action", "read"]
+  update = ["pwsh", "-File", "${path.module}/Command.ps1", "-Action", "update"]
+  delete = ["pwsh", "-File", "${path.module}/Command.ps1", "-Action", "delete"]
+  query = {
+    description = "This should fail to run"
+  }
+}
+
+output "id" { value = shell.default.id }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/Brightspace/terraform-provider-shell
 
 go 1.12
 
-require github.com/hashicorp/terraform v0.12.2
+require (
+	github.com/go-cmd/cmd v1.1.0
+	github.com/hashicorp/terraform v0.12.2
+)

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
+github.com/go-cmd/cmd v1.1.0 h1:LxXflJCRKNZgoKl/0TJdzIDSGFdik3zxaeyL1yXCTsI=
+github.com/go-cmd/cmd v1.1.0/go.mod h1:bkfdaV0aMvVwTINGdkU5jlQEd9gF0z4irQutl37pOd8=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
Adds a timeout feature for the execution of commands by the shell provider.

PowerShell commands that have edge cases where they hang indefinitely has been happening more frequently as I am rolling out improvements across the organization. I suspect this is related to how remote sessions are handled (as non-interactive flags are being ignored).

For the time being, this PR adds support for timeouts on command executions. I will be raising a pull request later that handles retries. When that is done, that will set the stage for some of the refactoring work for the API.

Related to #13 